### PR TITLE
:whale: #4 Docker対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN npm run build
 
 #FROM golang:1.13.6-alpine3.11 AS runtime
 FROM alpine:latest AS runtime
+ENV PSK_ALBUM_DATA_PATH=/app/data/album.json
+ENV PSK_ENABLE_LOGGING="true"
 COPY --from=backend-build /work/Backend/picture-store-keeper-backend /app/build-release/run
 COPY --from=frontend-build /work/Frontend/dist /app/build-release/frontend-dist
 WORKDIR /app/build-release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.13.6 AS backend-build
+COPY Backend /work/Backend
+WORKDIR /work/Backend
+RUN go get github.com/labstack/echo/...
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+RUN go build -ldflags "-s -w" -o picture-store-keeper-backend main.go
+
+FROM node:lts AS frontend-build
+COPY Frontend /work/Frontend
+WORKDIR /work/Frontend
+ENV VUE_APP_API_HOST="http://localhost:1323/"
+RUN npm install
+RUN npm run build
+
+#FROM golang:1.13.6-alpine3.11 AS runtime
+FROM alpine:latest AS runtime
+COPY --from=backend-build /work/Backend/picture-store-keeper-backend /app/build-release/run
+COPY --from=frontend-build /work/Frontend/dist /app/build-release/frontend-dist
+WORKDIR /app/build-release
+EXPOSE 1323
+CMD ["./run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ENV VUE_APP_API_HOST="http://localhost:1323/"
 RUN npm install
 RUN npm run build
 
-#FROM golang:1.13.6-alpine3.11 AS runtime
 FROM alpine:latest AS runtime
 ENV PSK_ALBUM_DATA_PATH=/app/data/album.json
 ENV PSK_ENABLE_LOGGING="true"

--- a/Frontend/src/main.ts
+++ b/Frontend/src/main.ts
@@ -14,7 +14,7 @@ Vue.use(Buefy, {
 });
 
 // initialize services
-const Host = 'http://localhost:1323/';
+const Host = process.env.VUE_APP_API_HOST || 'http://localhost:1323/';
 const AlbumAPIServiceInst = new AlbumAPIService(Host);
 const DirectoryAPIServiceInst = new DirectoryAPIService(Host);
 const MoveAPIServiceInst = new MoveAPIService(Host);


### PR DESCRIPTION
- とりあえず起動すればよい、という方針
- API 側の受け入れ PORT を外から与えられるようになっていないので、とりあえずデフォルトの `1323` で通信するようにしておく

使い方

```sh
$ DOCKER_BUILDKIT=1 docker build -t psk .
$ docker run --rm -p 1323:1323 -v $(pwd)/data:/app/data psk
```

ホスト側のディレクトリをコンテナの `/app/data` にマウントすることで `album.json` を永続化させている。パーミッション周りで使いづらいことがあるかもなのでそこは後々リファインする。

画面でラベルのディレクトリ名指定するところで、暗黙的に `/app/data` で色々やるようにしたほうが使いやすいかも